### PR TITLE
chore: update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-query": "^5.67.3",
         "@tanstack/react-router": "^1.114.17",
-        "@tanstack/router-devtools": "^1.114.18",
+        "@tanstack/router-devtools": "^1.114.21",
         "@vitejs/plugin-react": "^4.3.4",
         "axios": "^1.8.3",
         "class-variance-authority": "^0.7.1",
@@ -3923,12 +3923,12 @@
       }
     },
     "node_modules/@tanstack/react-router-devtools": {
-      "version": "1.114.18",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.114.18.tgz",
-      "integrity": "sha512-axyf1gR9amSg74RQXA9A0FgK9Y+sNm4JIGdhOqj9Bm2i2uzy3OYrKPZU/WVyP5Qq4oYVma2toZ7B2y3LlaGnCw==",
+      "version": "1.114.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.114.21.tgz",
+      "integrity": "sha512-umwT6OnrrRaB6W42X0gt6iemd0bJDFpi9vFysvdyQhm4FOpDOAUsYgt0oz7JexrHGLu8M1mx+vN6UgmVWJdpww==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/router-devtools-core": "^1.114.17",
+        "@tanstack/router-devtools-core": "^1.114.20",
         "solid-js": "^1.9.5"
       },
       "engines": {
@@ -3980,12 +3980,12 @@
       }
     },
     "node_modules/@tanstack/router-devtools": {
-      "version": "1.114.18",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.114.18.tgz",
-      "integrity": "sha512-SN7nEXWSqgieN1KVr4g7CSaQKRuTj994re45PRqyNrwR9dIMoHiLdhGV8cTpMqwQRbcyB54Vw7W8hCt6D/FmwQ==",
+      "version": "1.114.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.114.21.tgz",
+      "integrity": "sha512-pQ+Wxgm3KKyay9/5WfnpRmwe0pzOqMYB8BfAuTQiTDrYPpfREOkUnOiVIGrIeLqFw/2aoyXVppKPQO9IcxVQjA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-router-devtools": "^1.114.18",
+        "@tanstack/react-router-devtools": "^1.114.21",
         "clsx": "^2.1.1",
         "goober": "^2.1.16"
       },
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/@tanstack/router-devtools-core": {
-      "version": "1.114.17",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.114.17.tgz",
-      "integrity": "sha512-DOUvqXSI/GDhkPT9r9ltoTVvgBHSLIdR9f3k6Eg9fNd5Co3gBCrjWLuS9vbvMq/4xaTD6UbRzNWxaycZOF7NMw==",
+      "version": "1.114.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.114.20.tgz",
+      "integrity": "sha512-FJuV6PaGePefcQ/zN8/6vsEZ9OXy4LtdRpuOaYNRgFGJe76Z43TmN/yAjdPtNlczqUjL8Nl8siZ66uH5EJ+boQ==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/react-query": "^5.67.3",
     "@tanstack/react-router": "^1.114.17",
-    "@tanstack/router-devtools": "^1.114.18",
+    "@tanstack/router-devtools": "^1.114.21",
     "@vitejs/plugin-react": "^4.3.4",
     "axios": "^1.8.3",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
This PR updates dependencies to their latest versions.

Updated automatically via GitHub Actions after detecting available updates.


### NPM Package Updates
<details><summary>Show Updates</summary>

```json
{\n  "@tanstack/router-devtools": "^1.114.21"\n}
```
</details>


### Incorporated Dependabot PRs
<details><summary>Show Incorporated PRs (1 new, 0 previous)</summary>
The following Dependabot PRs were incorporated:

- PR #8: Bump babel-plugin-react-compiler from 0.0.0-experimental-fe484b5-20240912 to 0.0.0-experimental-7449567-20240905
  </details>
